### PR TITLE
screen function integrated

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-SHA-MQTT-ESP32-LIB
-version=1.0.0
+version=1.1.0
 author=SuperHouse Automation Pty Ltd
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 MQTT library for Open eXtensible Rack System projects

--- a/src/OXRS_MQTT.cpp
+++ b/src/OXRS_MQTT.cpp
@@ -6,10 +6,16 @@
 #include "Arduino.h"
 #include "OXRS_MQTT.h"
 
-OXRS_MQTT::OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen) 
+OXRS_MQTT::OXRS_MQTT(PubSubClient& client) 
 {
   this->_client = &client;
-  _screen = screen;
+  _screen = NULL;
+}
+
+OXRS_MQTT::OXRS_MQTT(PubSubClient& client, OXRS_LCD& screen) 
+{
+  this->_client = &client;
+  _screen = &screen;
 }
 
 void OXRS_MQTT::setClientId(const char * deviceId)

--- a/src/OXRS_MQTT.cpp
+++ b/src/OXRS_MQTT.cpp
@@ -6,9 +6,10 @@
 #include "Arduino.h"
 #include "OXRS_MQTT.h"
 
-OXRS_MQTT::OXRS_MQTT(PubSubClient& client) 
+OXRS_MQTT::OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen) 
 {
   this->_client = &client;
+  _screen = screen;
 }
 
 void OXRS_MQTT::setClientId(const char * deviceId)
@@ -60,6 +61,9 @@ char * OXRS_MQTT::getTelemetryTopic(char topic[])
 void OXRS_MQTT::onConfig(callback callback)
 { 
   _onConfig = callback; 
+  char topic[64];
+  getStatusTopic(topic);
+  _screen->show_MQTT_topic(topic);
 }
 
 void OXRS_MQTT::onCommand(callback callback)
@@ -114,6 +118,8 @@ void OXRS_MQTT::loop()
 
 void OXRS_MQTT::receive(char * topic, uint8_t * payload, unsigned int length) 
 {
+  _screen->trigger_mqtt_rx_led ();
+
   Serial.print(F("[recv] "));
   Serial.print(topic);
   Serial.print(F(" "));
@@ -176,6 +182,8 @@ boolean OXRS_MQTT::_publish(char topic[], JsonObject json)
   Serial.print(topic);
   Serial.print(F(" "));
   Serial.println(buffer);
+
+  _screen->trigger_mqtt_tx_led ();
   
   _client->publish(topic, buffer);
   return true;

--- a/src/OXRS_MQTT.cpp
+++ b/src/OXRS_MQTT.cpp
@@ -15,11 +15,13 @@ OXRS_MQTT::OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen)
 void OXRS_MQTT::setClientId(const char * deviceId)
 { 
   strcpy(_clientId, deviceId);
+  _showTopic();
 }
 
 void OXRS_MQTT::setClientId(const char * deviceType, byte deviceMac[6])
 { 
   sprintf_P(_clientId, PSTR("%s-%02x%02x%02x"), deviceType, deviceMac[3], deviceMac[4], deviceMac[5]);  
+  _showTopic();
 }
 
 void OXRS_MQTT::setAuth(const char * username, const char * password)
@@ -31,11 +33,13 @@ void OXRS_MQTT::setAuth(const char * username, const char * password)
 void OXRS_MQTT::setTopicPrefix(const char * prefix)
 { 
   strcpy(_topicPrefix, prefix);
+  _showTopic();
 }
 
 void OXRS_MQTT::setTopicSuffix(const char * suffix)
 { 
   strcpy(_topicSuffix, suffix);
+  _showTopic();
 }
 
 char * OXRS_MQTT::getConfigTopic(char topic[])
@@ -61,9 +65,6 @@ char * OXRS_MQTT::getTelemetryTopic(char topic[])
 void OXRS_MQTT::onConfig(callback callback)
 { 
   _onConfig = callback; 
-  char topic[64];
-  getStatusTopic(topic);
-  _screen->show_MQTT_topic(topic);
 }
 
 void OXRS_MQTT::onCommand(callback callback)
@@ -118,7 +119,7 @@ void OXRS_MQTT::loop()
 
 void OXRS_MQTT::receive(char * topic, uint8_t * payload, unsigned int length) 
 {
-  _screen->trigger_mqtt_rx_led ();
+  if (_screen) _screen->trigger_mqtt_rx_led ();
 
   Serial.print(F("[recv] "));
   Serial.print(topic);
@@ -183,7 +184,7 @@ boolean OXRS_MQTT::_publish(char topic[], JsonObject json)
   Serial.print(F(" "));
   Serial.println(buffer);
 
-  _screen->trigger_mqtt_tx_led ();
+  if (_screen) _screen->trigger_mqtt_tx_led ();
   
   _client->publish(topic, buffer);
   return true;
@@ -236,4 +237,12 @@ char * OXRS_MQTT::_getTopic(char topic[], const char * topicType)
   }
   
   return topic;
+}
+
+void OXRS_MQTT::_showTopic()
+{ 
+  char topic[64];
+
+  _getTopic(topic, "+");
+  if (_screen) _screen->show_MQTT_topic(topic);
 }

--- a/src/OXRS_MQTT.h
+++ b/src/OXRS_MQTT.h
@@ -9,6 +9,8 @@
 #include "Arduino.h"
 #include <ArduinoJson.h>
 #include <PubSubClient.h>
+#include <OXRS_LCD.h>
+
 
 static const char * MQTT_CONFIG_TOPIC     = "conf";
 static const char * MQTT_COMMAND_TOPIC    = "cmnd";
@@ -31,7 +33,7 @@ typedef void (*callback)(JsonObject);
 class OXRS_MQTT
 {
   public:
-    OXRS_MQTT(PubSubClient& client);
+    OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen);
 
     void setClientId(const char * deviceId);
     void setClientId(const char * deviceType, byte deviceMac[6]);
@@ -66,6 +68,8 @@ class OXRS_MQTT
     
     uint8_t _backoff;
     uint32_t _lastReconnectMs;
+    
+    OXRS_LCD * _screen;
 
     boolean _connect();
 

--- a/src/OXRS_MQTT.h
+++ b/src/OXRS_MQTT.h
@@ -33,7 +33,8 @@ typedef void (*callback)(JsonObject);
 class OXRS_MQTT
 {
   public:
-    OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen=NULL);
+    OXRS_MQTT(PubSubClient& client);
+    OXRS_MQTT(PubSubClient& client, OXRS_LCD& screen);
 
     void setClientId(const char * deviceId);
     void setClientId(const char * deviceType, byte deviceMac[6]);

--- a/src/OXRS_MQTT.h
+++ b/src/OXRS_MQTT.h
@@ -33,7 +33,7 @@ typedef void (*callback)(JsonObject);
 class OXRS_MQTT
 {
   public:
-    OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen);
+    OXRS_MQTT(PubSubClient& client, OXRS_LCD * screen=NULL);
 
     void setClientId(const char * deviceId);
     void setClientId(const char * deviceType, byte deviceMac[6]);
@@ -78,6 +78,7 @@ class OXRS_MQTT
 
     char * _getTopic(char topic[], const char * topicType);
     boolean _publish(char topic[], JsonObject json);
+    void _showTopic();
 };
 
 #endif


### PR DESCRIPTION
OXRS_mqtt lib takes care for screen display on it's own

This follows hopefully your suggestions. This branch is not necessary the final solution - take it as proof of concept and make corrections as you think are appropriate.
the function  `onConfig()`  is propably not the right place to call `show_MQTT_topic(topic);` , but I couldn't find a better place for now. I'm sure you will solve that