### PR TITLE
remove lcd dependency from mqtt library

### DIFF
--- a/src/OXRS_MQTT.cpp
+++ b/src/OXRS_MQTT.cpp
@@ -9,25 +9,16 @@
 OXRS_MQTT::OXRS_MQTT(PubSubClient& client) 
 {
   this->_client = &client;
-  _screen = NULL;
-}
-
-OXRS_MQTT::OXRS_MQTT(PubSubClient& client, OXRS_LCD& screen) 
-{
-  this->_client = &client;
-  _screen = &screen;
 }
 
 void OXRS_MQTT::setClientId(const char * deviceId)
 { 
   strcpy(_clientId, deviceId);
-  _showTopic();
 }
 
 void OXRS_MQTT::setClientId(const char * deviceType, byte deviceMac[6])
 { 
   sprintf_P(_clientId, PSTR("%s-%02x%02x%02x"), deviceType, deviceMac[3], deviceMac[4], deviceMac[5]);  
-  _showTopic();
 }
 
 void OXRS_MQTT::setAuth(const char * username, const char * password)
@@ -39,13 +30,11 @@ void OXRS_MQTT::setAuth(const char * username, const char * password)
 void OXRS_MQTT::setTopicPrefix(const char * prefix)
 { 
   strcpy(_topicPrefix, prefix);
-  _showTopic();
 }
 
 void OXRS_MQTT::setTopicSuffix(const char * suffix)
 { 
   strcpy(_topicSuffix, suffix);
-  _showTopic();
 }
 
 char * OXRS_MQTT::getConfigTopic(char topic[])
@@ -125,8 +114,6 @@ void OXRS_MQTT::loop()
 
 void OXRS_MQTT::receive(char * topic, uint8_t * payload, unsigned int length) 
 {
-  if (_screen) _screen->trigger_mqtt_rx_led ();
-
   Serial.print(F("[recv] "));
   Serial.print(topic);
   Serial.print(F(" "));
@@ -190,8 +177,6 @@ boolean OXRS_MQTT::_publish(char topic[], JsonObject json)
   Serial.print(F(" "));
   Serial.println(buffer);
 
-  if (_screen) _screen->trigger_mqtt_tx_led ();
-  
   _client->publish(topic, buffer);
   return true;
 }
@@ -243,12 +228,4 @@ char * OXRS_MQTT::_getTopic(char topic[], const char * topicType)
   }
   
   return topic;
-}
-
-void OXRS_MQTT::_showTopic()
-{ 
-  char topic[64];
-
-  _getTopic(topic, "+");
-  if (_screen) _screen->show_MQTT_topic(topic);
 }

--- a/src/OXRS_MQTT.h
+++ b/src/OXRS_MQTT.h
@@ -9,8 +9,6 @@
 #include "Arduino.h"
 #include <ArduinoJson.h>
 #include <PubSubClient.h>
-#include <OXRS_LCD.h>
-
 
 static const char * MQTT_CONFIG_TOPIC     = "conf";
 static const char * MQTT_COMMAND_TOPIC    = "cmnd";
@@ -34,7 +32,6 @@ class OXRS_MQTT
 {
   public:
     OXRS_MQTT(PubSubClient& client);
-    OXRS_MQTT(PubSubClient& client, OXRS_LCD& screen);
 
     void setClientId(const char * deviceId);
     void setClientId(const char * deviceType, byte deviceMac[6]);
@@ -70,8 +67,6 @@ class OXRS_MQTT
     uint8_t _backoff;
     uint32_t _lastReconnectMs;
     
-    OXRS_LCD * _screen;
-
     boolean _connect();
 
     callback _onConfig;
@@ -79,7 +74,6 @@ class OXRS_MQTT
 
     char * _getTopic(char topic[], const char * topicType);
     boolean _publish(char topic[], JsonObject json);
-    void _showTopic();
 };
 
 #endif


### PR DESCRIPTION
I know it was my idea to do it this way but I think it is cleaner if we remove this dependency. 

I was trying to get the smoke detector firmware running on a device with no LCD and the MQTT library was complaining because of the LCD dependency. 
