### PR TITLE
switch to (buffered) streamed publishing of JSON payloads

### DIFF
--- a/src/OXRS_MQTT.cpp
+++ b/src/OXRS_MQTT.cpp
@@ -6,7 +6,9 @@
 #include "Arduino.h"
 #include "OXRS_MQTT.h"
 
+#ifdef MQTT_ENABLE_STREAMING
 #include <StreamUtils.h>
+#endif
 
 OXRS_MQTT::OXRS_MQTT(PubSubClient& client) 
 {
@@ -301,14 +303,19 @@ boolean OXRS_MQTT::_publish(JsonVariant json, char * topic, boolean retained)
 {
   if (!_client->connected()) { return false; }
   
-  // Publish the JSON as a buffered stream rather using a temporary
-  // buffer in memory, since our payloads could be quite large
+#ifdef MQTT_ENABLE_STREAMING
+  // Publish as a buffered stream
   _client->beginPublish(topic, measureJson(json), retained);
-  
-  BufferingPrint bufferedClient(*_client, 32);
+  BufferingPrint bufferedClient(*_client, MQTT_STREAMING_BUFFER_SIZE);
   serializeJson(json, bufferedClient);
   bufferedClient.flush();
-
   _client->endPublish();
+#else
+  // Write to a temporary buffer and then publish
+  char buffer[MQTT_MAX_MESSAGE_SIZE];
+  serializeJson(json, buffer);
+  _client->publish(topic, buffer, retained);  
+#endif
+
   return true;
 }

--- a/src/OXRS_MQTT.h
+++ b/src/OXRS_MQTT.h
@@ -10,20 +10,22 @@
 #include <ArduinoJson.h>
 #include <PubSubClient.h>
 
-#define MQTT_DEFAULT_PORT           1883
-#define MQTT_BACKOFF_SECS           5
-#define MQTT_MAX_BACKOFF_COUNT      12
-
+// Increase the max MQTT message size for ESP based MCUs
 #if (defined ESP8266 || defined ESP32)
-#define MQTT_MAX_MESSAGE_SIZE       4096
+#define MQTT_MAX_MESSAGE_SIZE           4096
 #else
-#define MQTT_MAX_MESSAGE_SIZE       256
+#define MQTT_MAX_MESSAGE_SIZE           256
 #endif
 
-static const char * MQTT_CONFIG_TOPIC     = "conf";
-static const char * MQTT_COMMAND_TOPIC    = "cmnd";
-static const char * MQTT_STATUS_TOPIC     = "stat";
-static const char * MQTT_TELEMETRY_TOPIC  = "tele";
+// Enable streaming for ESP based MCUs
+#if (defined ESP8266 || defined ESP32)
+#define MQTT_ENABLE_STREAMING
+#endif
+
+#define MQTT_DEFAULT_PORT               1883
+#define MQTT_BACKOFF_SECS               5
+#define MQTT_MAX_BACKOFF_COUNT          12
+#define MQTT_STREAMING_BUFFER_SIZE      64
 
 // Return codes for receive()
 #define MQTT_RECEIVE_OK                 0
@@ -31,6 +33,12 @@ static const char * MQTT_TELEMETRY_TOPIC  = "tele";
 #define MQTT_RECEIVE_JSON_ERROR         2
 #define MQTT_RECEIVE_NO_CONFIG_HANDLER  3
 #define MQTT_RECEIVE_NO_COMMAND_HANDLER 4
+
+// Topic constants
+static const char * MQTT_CONFIG_TOPIC     = "conf";
+static const char * MQTT_COMMAND_TOPIC    = "cmnd";
+static const char * MQTT_STATUS_TOPIC     = "stat";
+static const char * MQTT_TELEMETRY_TOPIC  = "tele";
 
 // Callback types for onConnected()
 typedef void (* connectedCallback)(void);


### PR DESCRIPTION
Hey Moin - would you mind having a look at this and testing locally if possible?

I was having trouble on one of my ESP8266 based devices when trying to publish a large `/adopt` payload. I think it was blowing some internal buffers in the PubSubClient.

Anyway - I did some reading and the ArduinoJson docs suggest using buffered streaming/printing rather than a temporary in-memory buffer, where serialising JSON payloads out to MQTT.

It is working here but I would like some extra testing before merging.