### PR TITLE
increase MQTT_MAX_MESSAGE_SIZE to 16kB to allow for very large config payloads

### DIFF
--- a/src/OXRS_MQTT.h
+++ b/src/OXRS_MQTT.h
@@ -12,7 +12,7 @@
 
 // Increase the max MQTT message size for ESP based MCUs
 #if (defined ESP8266 || defined ESP32)
-#define MQTT_MAX_MESSAGE_SIZE           4096
+#define MQTT_MAX_MESSAGE_SIZE           16384
 #else
 #define MQTT_MAX_MESSAGE_SIZE           256
 #endif


### PR DESCRIPTION
Should fix https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW/issues/15.